### PR TITLE
Add FiberHMM documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -24,6 +24,13 @@
 
 ---
 
+- [FiberHMM](fiberhmm/fiberhmm.md)
+    - [Installation and usage](fiberhmm/usage.md)
+    - [Pre-trained models](fiberhmm/models.md)
+    - [How it works](fiberhmm/methods.md)
+
+---
+
 - [FIRE](fire/fire.md)
     - [Running and installing](fire/run.md)
     - [Outputs](fire/outputs.md)

--- a/src/fiberhmm/fiberhmm.md
+++ b/src/fiberhmm/fiberhmm.md
@@ -1,0 +1,18 @@
+# FiberHMM: HMM-based chromatin footprint calling
+
+[![GitHub](https://img.shields.io/github/v/release/fiberseq/FiberHMM?color=green)](https://github.com/fiberseq/FiberHMM)
+[![PyPI](https://img.shields.io/pypi/v/fiberhmm)](https://pypi.org/project/fiberhmm/)
+
+FiberHMM is a hidden Markov model toolkit for calling chromatin footprints and methylase-sensitive patches (MSPs) from single-molecule data. It works with Fiber-seq (m6A via Hia5) and DAF-seq (deamination via DddA/DddB), producing fibertools-compatible BAM output with `ns`/`nl`/`as`/`al` tags.
+
+By learning sequence-context-specific emission probabilities from control data, FiberHMM accounts for the large biases in methylation efficiency across different hexamer contexts. This is what enables accurate footprint calling at much smaller sizes than heuristic approaches -- resolving not just nucleosomes but also transcription factor binding sites, Pol II, and other sub-nucleosomal footprints that would otherwise be lost in context noise.
+
+FiberHMM also provides a unified framework for calling footprints across different single-molecule chemistries (Hia5, DddA, DddB) and sequencing platforms (PacBio, Nanopore), making it straightforward to directly compare chromatin accessibility measurements between experiments.
+
+This chapter covers:
+
+- [Installation and usage](usage.md)
+- [Pre-trained models](models.md)
+- [How it works](methods.md)
+
+The source code and full documentation can be found on [GitHub](https://github.com/fiberseq/FiberHMM).

--- a/src/fiberhmm/methods.md
+++ b/src/fiberhmm/methods.md
@@ -1,0 +1,45 @@
+# How FiberHMM works
+
+## The problem
+
+Single-molecule chromatin assays (Fiber-seq, DAF-seq) mark accessible DNA with enzymatic modifications -- m6A methylation or cytosine deamination. But the efficiency of these enzymes depends on the local sequence context: some hexamers are methylated much more readily than others, even in fully accessible DNA. Without accounting for this, a naive threshold would over-call footprints in low-efficiency contexts and under-call them in high-efficiency ones.
+
+## The approach
+
+FiberHMM uses a two-state hidden Markov model where:
+
+- **State 0 (inaccessible)**: The DNA is nucleosome-protected or otherwise inaccessible. Modification rates are low.
+- **State 1 (accessible)**: The DNA is in a methylase-sensitive patch (MSP). Modification rates are high.
+
+The key insight is that emission probabilities are learned per sequence context (hexamer) from control data, so the model knows the expected modification rate for each context in each state. This allows it to correctly interpret a low modification rate at a context that is inherently hard to methylate versus a genuinely protected region.
+
+## Pipeline steps
+
+### 1. Emission probability estimation
+
+Control BAMs define how modification rates differ between accessible and inaccessible states:
+
+- **Accessible control** (e.g., naked DNA treated with methyltransferase): Gives `P(modified | accessible, context)` for each hexamer
+- **Inaccessible control** (e.g., native chromatin): Gives `P(modified | inaccessible, context)` for each hexamer
+
+These context-specific emission probabilities are stored as TSV tables, one per context size `k`.
+
+### 2. Training
+
+The Baum-Welch (EM) algorithm learns the transition probabilities and start probabilities from sample data, while the emission probabilities remain fixed from the control data. Multiple random initializations are used to avoid local optima, and the model with the best log-likelihood is selected.
+
+### 3. Decoding
+
+The Viterbi algorithm finds the most likely state sequence for each read. Contiguous runs of state 0 become footprints; contiguous runs of state 1 become MSPs. Optionally, the forward-backward algorithm computes posterior probabilities for per-footprint confidence scores.
+
+## Sequence context encoding
+
+Each position on a read is encoded as a hexamer centered on the target base (for `k=3`, a 7-mer). The hexamer is mapped to an integer code using a deterministic lookup table. For PacBio fiber-seq, reverse complement contexts are merged to account for double-stranded m6A detection. The total number of symbols is `4^(2k)` (or `4^(2k) * 2` with separate modified/unmodified codes).
+
+Context is computed directly from the read sequence -- no genome reference or context files are needed.
+
+## Why context matters for small footprints
+
+Nucleosome-scale footprints (~150 bp) are large enough that context biases average out over the footprint length. But for smaller features -- transcription factor binding sites (~10-30 bp), Pol II (~50 bp) -- individual hexamer biases dominate the signal. A 20 bp stretch of low-efficiency contexts can look identical to a genuine TF footprint if context isn't modeled.
+
+By learning the expected modification rate for each hexamer in each chromatin state, FiberHMM can distinguish true small footprints from context artifacts, enabling accurate sub-nucleosomal footprint calling.

--- a/src/fiberhmm/models.md
+++ b/src/fiberhmm/models.md
@@ -1,0 +1,47 @@
+# Pre-trained models
+
+FiberHMM ships with pre-trained models in the `models/` directory. These can be used directly with `fiberhmm-apply` without needing to generate emission probabilities or train from scratch.
+
+## Available models
+
+| Model | File | Enzyme | Platform | Mode | Organism |
+|-------|------|--------|----------|------|----------|
+| **Hia5 PacBio** | `hia5_pacbio.json` | Hia5 (m6A) | PacBio | `pacbio-fiber` | Drosophila |
+| **Hia5 Nanopore** | `hia5_nanopore.json` | Hia5 (m6A) | Nanopore | `nanopore-fiber` | Yeast |
+| **DddA PacBio** | `ddda_pacbio.json` | DddA (deamination) | PacBio | `daf` | Drosophila |
+| **DddB Nanopore** | `dddb_nanopore.json` | DddB (deamination) | Nanopore | `daf` | Drosophila |
+
+## Using a pre-trained model
+
+```bash
+# PacBio Hia5 fiber-seq
+fiberhmm-apply -i experiment.bam -m models/hia5_pacbio.json -o output/ -c 8
+
+# Nanopore Hia5 fiber-seq
+fiberhmm-apply -i experiment.bam -m models/hia5_nanopore.json -o output/ -c 8
+
+# DAF-seq (DddA or DddB)
+fiberhmm-apply -i experiment.bam -m models/ddda_pacbio.json -o output/ -c 8 --mode daf
+```
+
+The mode and context size are stored in the model JSON and auto-detected at runtime, so you generally do not need to specify `--mode` or `-k` when using a pre-trained model.
+
+## When to train your own model
+
+The pre-trained models work well as a starting point, but you may want to train a custom model if:
+
+- You are working with a different organism where chromatin structure differs substantially
+- You are using a different methyltransferase or deaminase chemistry
+- You have matched accessible and inaccessible controls for your specific experiment
+
+See the [usage guide](usage.md) for the full training pipeline.
+
+## Inspecting a model
+
+You can inspect any model's parameters with:
+
+```bash
+fiberhmm-utils inspect models/hia5_pacbio.json
+```
+
+This prints the mode, context size, start probabilities, transition matrix, and emission probability summary statistics.

--- a/src/fiberhmm/usage.md
+++ b/src/fiberhmm/usage.md
@@ -1,0 +1,127 @@
+# Installation and usage
+
+## Install
+
+```bash
+pip install fiberhmm
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/fiberseq/FiberHMM.git
+cd FiberHMM
+pip install -e .
+```
+
+Optional: install `numba` for ~10x faster HMM computation, and `matplotlib` for `--stats` diagnostic plots.
+
+```bash
+pip install numba matplotlib
+```
+
+## Pipeline overview
+
+FiberHMM has four main steps, each with a dedicated command:
+
+1. **Generate emission probabilities** from control data (`fiberhmm-probs`)
+2. **Train the HMM** on your sample (`fiberhmm-train`)
+3. **Call footprints** on your experiment (`fiberhmm-apply`)
+4. **Extract to BED12/bigBed** for visualization (`fiberhmm-extract`)
+
+If you already have a [pre-trained model](models.md) for your chemistry, you can skip directly to step 3.
+
+## Generating emission probabilities
+
+This requires two control BAMs: one with accessible (naked/dechromatinized) DNA and one with inaccessible (native chromatin) DNA. These define how methylation rates differ between accessible and inaccessible states for each sequence context.
+
+```bash
+fiberhmm-probs \
+    -a accessible_control.bam \
+    -u inaccessible_control.bam \
+    -o probs/ \
+    --mode pacbio-fiber \
+    --stats
+```
+
+This produces emission probability tables in `probs/tables/` for each context size.
+
+## Training the HMM
+
+```bash
+fiberhmm-train \
+    -i sample.bam \
+    -p probs/tables/accessible_A_k3.tsv probs/tables/inaccessible_A_k3.tsv \
+    -o models/ \
+    -k 3 \
+    --stats
+```
+
+Output: `models/best-model.json` (the trained model).
+
+## Calling footprints
+
+```bash
+fiberhmm-apply \
+    -i experiment.bam \
+    -m models/best-model.json \
+    -o output/ \
+    -c 8 \
+    --scores
+```
+
+This writes a BAM file with fibertools-compatible footprint tags:
+
+| Tag | Type | Description |
+|-----|------|-------------|
+| `ns` | B,I | Footprint starts (0-based query coords) |
+| `nl` | B,I | Footprint lengths |
+| `as` | B,I | MSP starts |
+| `al` | B,I | MSP lengths |
+| `nq` | B,C | Footprint quality scores (0-255, with `--scores`) |
+| `aq` | B,C | MSP quality scores (0-255, with `--scores`) |
+
+The output BAM is compatible with `ft extract`, FIRE, and any other tool that reads fibertools-style tags.
+
+## Extracting to BED12/bigBed
+
+```bash
+fiberhmm-extract -i output/experiment_footprints.bam
+```
+
+This produces bigBed files for footprints, MSPs, m6A, and m5C that can be loaded into genome browsers.
+
+## Analysis modes
+
+| Mode | Flag | Chemistry | Target bases |
+|------|------|-----------|--------------|
+| **PacBio fiber-seq** | `--mode pacbio-fiber` | Hia5 m6A, both strands | A, T (with RC) |
+| **Nanopore fiber-seq** | `--mode nanopore-fiber` | Hia5 m6A, single strand | A only |
+| **DAF-seq** | `--mode daf` | DddA/DddB deamination | C or G |
+
+The `pacbio-fiber` vs `nanopore-fiber` distinction only matters for Hia5, where PacBio detects modifications on both strands while Nanopore detects only one. For deaminase-based methods (DddA, DddB), `--mode daf` is always used regardless of sequencing platform.
+
+## Utilities
+
+`fiberhmm-utils` provides additional commands for model management:
+
+```bash
+# Convert legacy models to JSON
+fiberhmm-utils convert old_model.pickle new_model.json
+
+# Inspect model parameters
+fiberhmm-utils inspect model.json
+
+# Transfer emission probs between chemistries
+fiberhmm-utils transfer --target daf.bam --reference-bam fiber.bam -o probs/ --mode daf
+
+# Scale emission probabilities
+fiberhmm-utils adjust model.json --state accessible --scale 1.1 -o adjusted.json
+```
+
+## Performance tips
+
+- Use `-c 8` (or more cores) for parallel footprint calling
+- For small genomes, reduce `--region-size` (500KB for yeast, 2MB for Drosophila)
+- Install `numba` for faster HMM training
+- Use `--skip-scaffolds` to avoid processing thousands of contigs


### PR DESCRIPTION
## Summary

Adds documentation for [FiberHMM](https://github.com/fiberseq/FiberHMM), an HMM-based chromatin footprint caller for Fiber-seq and DAF-seq data.

**New pages** (in `src/fiberhmm/`):
- **Overview** — what FiberHMM does, context-aware sub-nucleosomal footprinting, cross-chemistry support
- **Installation and usage** — pip install, full pipeline walkthrough (probs → train → apply → extract)
- **Pre-trained models** — Hia5 (PacBio/Nanopore), DddA (PacBio), DddB (Nanopore)
- **How it works** — HMM approach, emission probability estimation, context encoding, why context matters for small footprints

**Navigation** — added as a top-level section in SUMMARY.md between fibertools and FIRE.

